### PR TITLE
replace china specific DNS with general DNS

### DIFF
--- a/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
+++ b/V2rayNG/app/src/main/kotlin/com/v2ray/ang/AppConfig.kt
@@ -103,7 +103,7 @@ object AppConfig {
     const val DelayTestUrl2 = "https://www.google.com/generate_204"
 
     const val DNS_PROXY = "1.1.1.1"
-    const val DNS_DIRECT = "223.5.5.5"
+    const val DNS_DIRECT = "1.1.1.1"
     const val DNS_VPN = "1.1.1.1"
 
     const val PORT_LOCAL_DNS = "10853"


### PR DESCRIPTION
china specific DNS doesn't have good performance in Iran. So it is recommended to replace it with a general one.